### PR TITLE
Update Fiat 500 generations: fix end year and add Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Fiat 500
 
+This repository contains signal set configurations for the Fiat 500, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Fiat 500.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,7 @@
+references:
+  - "https://en.wikipedia.org/wiki/Fiat_500"
+  - "https://en.wikipedia.org/wiki/Fiat_500_(2007)"
+
 generations:
   - name: "Original (Nuova 500)"
     start_year: 1957
@@ -6,5 +10,5 @@ generations:
 
   - name: "Modern Fiat 500 (Type 312)"
     start_year: 2007
-    end_year: null
-    description: "The modern Fiat 500 was introduced on the 50th anniversary of the original model, featuring retro-inspired styling that evoked the 1957 version but with contemporary engineering and safety features. Built on Fiat's Mini platform shared with the Panda, it maintained compact dimensions but with significantly more interior space and comfort than its predecessor. Initially powered by a range of small gasoline and diesel engines, including the 1.4L 16v with 100 HP in the Sport variant, the engine lineup evolved over time to include more efficient turbocharged options like the TwinAir and MultiAir units. The interior combined vintage-inspired design elements with modern technology, featuring a body-colored dashboard panel and circular design motifs. A significant mid-life update in 2015 brought over 1,800 changes, including updated styling, improved infotainment, and enhanced safety features. Special variants have included the performance-oriented Abarth models, the 500C with a retractable fabric roof, and numerous limited and special editions featuring designer collaborations. Despite its age, the Type 312 platform continues in production alongside the newer electric 500, maintaining its popularity as a style-focused city car with immense personalization options. Throughout its production, the modern 500 has maintained its essence as a fashionable, premium small car that successfully reinterpreted a classic design for contemporary consumers."
+    end_year: 2024
+    description: "The modern Fiat 500 was introduced on the 50th anniversary of the original model, featuring retro-inspired styling that evoked the 1957 version but with contemporary engineering and safety features. Built on Fiat's Mini platform shared with the Panda, it maintained compact dimensions but with significantly more interior space and comfort than its predecessor. Initially powered by a range of small gasoline and diesel engines, including the 1.4L 16v with 100 HP in the Sport variant, the engine lineup evolved over time to include more efficient turbocharged options like the TwinAir and MultiAir units. The interior combined vintage-inspired design elements with modern technology, featuring a body-colored dashboard panel and circular design motifs. A significant mid-life facelift in 2016 brought updated styling, improved infotainment, and enhanced safety features. Special variants have included the performance-oriented Abarth models, the 500C with a retractable fabric roof, and numerous limited and special editions featuring designer collaborations. Production ended in August 2024 in Poland, after 17 years of continuous production. Throughout its production, the modern 500 has maintained its essence as a fashionable, premium small car that successfully reinterpreted a classic design for contemporary consumers."


### PR DESCRIPTION
- Changed Modern Fiat 500 (Type 312) end_year from null to 2024 (production ended August 2024 in Poland)
- Updated description to reflect 2016 facelift (not mid-life update) and production end date
- Added references array with Wikipedia article URLs
- Updated README.md with standard template

Evidence: Wikipedia article "Fiat 500 (2007)" states production ended in August 2024 in Poland after 17 years

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
